### PR TITLE
No longer provide a feature in test-helper.el

### DIFF
--- a/test/emr-css-test.el
+++ b/test/emr-css-test.el
@@ -26,7 +26,6 @@
 ;;; Code:
 
 (require 'emr-css)
-(require 'test-helper)
 
 (check "css--adds !important"
   (with-temp-buffer

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -47,6 +47,4 @@ BODY lists the forms to be executed."
   "Assert that objects X and Y are equal."
   (should (equal x y)))
 
-(provide 'test-helper)
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
The file isn't a library intended to be loaded with `require`.
Instead `ert-runner` loads it using `load`.  Other packages that
use `ert-runner` also come with a file named test-helper.el and
unfortunately many of those also provide `test-helper`, which
leads to conflicts.

Fixes #25.