### PR TITLE
Use ert-deftest rather than a custom check macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,13 @@ env:
   - EVM_EMACS=emacs-25.1-travis
   - EVM_EMACS=emacs-git-snapshot
 
+addons:
+  apt:
+    packages:
+    - texinfo
+    - libgif-dev
+    - libxpm-dev
+
 matrix:
   fast_finish: true
   allow_failures:

--- a/emr-elisp.el
+++ b/emr-elisp.el
@@ -1164,7 +1164,7 @@ the cdr is the usage form."
       (emr-collapse-vertical-whitespace))))
 
 ;;; `emr-el-ref': A reference to a function or variable within a file.
-(defstruct emr-el-ref file line col identifier type form)
+(cl-defstruct emr-el-ref file line col identifier type form)
 
 (defun emr-el:find-unused-defs ()
   "Return a list of all unused definitions in the buffer.

--- a/test/emr-css-test.el
+++ b/test/emr-css-test.el
@@ -27,7 +27,8 @@
 
 (require 'emr-css)
 
-(check "css--adds !important"
+(ert-deftest emr-css-add-important ()
+  "Add !important in CSS."
   (with-temp-buffer
     (css-mode)
     (insert "display: block;")
@@ -37,7 +38,8 @@
       (buffer-string)
       "display: block !important;"))))
 
-(check "css--removes !important"
+(ert-deftest emr-css-remove-important ()
+  "Remove !important if present in CSS."
   (with-temp-buffer
     (css-mode)
     (insert "display: block !important;")

--- a/test/emr-css-test.el
+++ b/test/emr-css-test.el
@@ -32,18 +32,20 @@
     (css-mode)
     (insert "display: block;")
     (emr-css-toggle-important)
-    (should=
-     (buffer-string)
-     "display: block !important;")))
+    (should
+     (equal
+      (buffer-string)
+      "display: block !important;"))))
 
 (check "css--removes !important"
   (with-temp-buffer
     (css-mode)
     (insert "display: block !important;")
     (emr-css-toggle-important)
-    (should=
-     (buffer-string)
-     "display: block;")))
+    (should
+     (equal
+      (buffer-string)
+      "display: block;"))))
 
 (provide 'emr-css-test)
 

--- a/test/emr-elisp-test.el
+++ b/test/emr-elisp-test.el
@@ -27,14 +27,16 @@
 
 ;;;; Function implementation.
 
-(check "elisp--uses symbol names when inferring arglists from callsites"
+(ert-deftest emr-elisp-symbol-names ()
+  "elisp--uses symbol names when inferring arglists from callsites"
   (let ((fname (cl-gensym)))
     (should
      (equal
       '(x y)
       (emr-el:infer-arglist-for-usage `(,fname x y))))))
 
-(check "elisp--uses argn for non-symbol names when inferring arglists from callsites"
+(ert-deftest emr-elisp-argn ()
+  "elisp--uses argn for non-symbol names when inferring arglists from callsites"
   (should
    (equal
     '(arg1 arg2)
@@ -42,7 +44,8 @@
 
 ;;;; Bound variables
 
-(check "elisp--finds free vars in let form"
+(ert-deftest emr-elisp-free-vars-let ()
+  "elisp--finds free vars in let form"
   (should
    (equal
     '(a b c d)
@@ -54,7 +57,8 @@
           c
           (list d)))))))
 
-(check "elisp--quoted vars are not free variables"
+(ert-deftest emr-elisp-quoted-vars ()
+  "elisp--quoted vars are not free variables"
   (should
    (equal
     '(x)
@@ -62,7 +66,8 @@
     (emr-el:free-variables
      '(list x 'y)))))
 
-(check "elisp--finds free vars in let* form"
+(ert-deftest emr-elisp-free-vars-let* ()
+  "elisp--finds free vars in let* form"
   (should
    (equal
     '(a b c d)
@@ -74,7 +79,8 @@
           c
           (list d)))))))
 
-(check "elisp--finds free vars in lambda form"
+(ert-deftest emr-elisp-free-vars-lambda ()
+  "elisp--finds free vars in lambda form"
   (should
    (equal
     '(a b c)
@@ -86,7 +92,8 @@
         (lambda (z w)
           c))))))
 
-(check "elisp--finds free vars in progn form"
+(ert-deftest emr-elisp-free-vars-progn ()
+  "elisp--finds free vars in progn form"
   (should
    (equal
     '(a b c)
@@ -97,7 +104,8 @@
         (lambda (x &rest y) b)
         (let (z w) c))))))
 
-(check "elisp--finds free vars in cl-destructuring-bind"
+(ert-deftest emr-elisp-free-vars-bind ()
+  "elisp--finds free vars in cl-destructuring-bind"
   (should
    (equal
     '(a b c d)
@@ -109,7 +117,8 @@
         (cl-destructuring-bind (z . w) (list 3 4 5)
           (list c d)))))))
 
-(check "elisp--finds free vars in defun form"
+(ert-deftest emr-free-vars-defun ()
+  "elisp--finds free vars in defun form"
   (should
    (equal
     '(a b)
@@ -120,7 +129,8 @@
         (progn
           (list b y)))))))
 
-(check "elisp--survives function symbol followed by non-lambda term"
+(ert-deftest emr-elisp-free-vars-function-sym ()
+  "elisp--survives function symbol followed by non-lambda term"
   (let ((fname (cl-gensym)))
     (should
      (equal
@@ -129,7 +139,8 @@
       (emr-el:free-variables
        `(function ,fname))))))
 
-(check "elisp--checks outer scope for bindings that share names with functions"
+(ert-deftest emr-elisp-free-vars-outer-scope ()
+  "elisp--checks outer scope for bindings that share names with functions"
   (should
    (equal
     '(message y)
@@ -140,7 +151,8 @@
 
 ;;;; Inspecting forms at point
 
-(check "elisp--a top level let is not a definition"
+(ert-deftest emr-elisp-top-level-let ()
+  "elisp--a top level let is not a definition"
   (with-temp-buffer
     (insert "(let ((x 1))\n  (message \"foo: %s %s\" x 'bar))")
     (goto-char (point-min))
@@ -210,7 +222,7 @@ AFTER:
     (assert (s-contains? "AFTER:" docstring))
     (assert (s-contains? "|" docstring)))
 
-  `(check ,(format "elisp--%s" fname)
+  `(ert-deftest ,fname ()
      ;; `documentation' returns the functions docstring concatenated with
      ;; its arglist. Remove the arglist.
      (let ((docstring (->> (documentation ',fname)

--- a/test/emr-elisp-test.el
+++ b/test/emr-elisp-test.el
@@ -27,6 +27,10 @@
 
 ;;;; Function implementation.
 
+(require 'emr-elisp)
+(require 'dash)
+(require 's)
+
 (ert-deftest emr-elisp-symbol-names ()
   "elisp--uses symbol names when inferring arglists from callsites"
   (let ((fname (cl-gensym)))
@@ -161,7 +165,7 @@
 
 ;;;; Commands
 
-(defstruct emr-el-test-spec form before after)
+(cl-defstruct emr-el-test-spec form before after)
 
 (defun emr-el-test:example-call-from-docstring (str)
   "Extract the function usage form from a docstring test spec."

--- a/test/emr-elisp-test.el
+++ b/test/emr-elisp-test.el
@@ -29,103 +29,114 @@
 
 (check "elisp--uses symbol names when inferring arglists from callsites"
   (let ((fname (cl-gensym)))
-    (should=
-     '(x y)
-     (emr-el:infer-arglist-for-usage `(,fname x y)))))
+    (should
+     (equal
+      '(x y)
+      (emr-el:infer-arglist-for-usage `(,fname x y))))))
 
 (check "elisp--uses argn for non-symbol names when inferring arglists from callsites"
-  (should=
-   '(arg1 arg2)
-   (emr-el:infer-arglist-for-usage '(hello 9 8))))
+  (should
+   (equal
+    '(arg1 arg2)
+    (emr-el:infer-arglist-for-usage '(hello 9 8)))))
 
 ;;;; Bound variables
 
 (check "elisp--finds free vars in let form"
-  (should=
-   '(a b c d)
+  (should
+   (equal
+    '(a b c d)
 
-   (emr-el:free-variables
-    '(let (x (y a))
-       b
-       (let (z w)
-         c
-         (list d))))))
+    (emr-el:free-variables
+     '(let (x (y a))
+        b
+        (let (z w)
+          c
+          (list d)))))))
 
 (check "elisp--quoted vars are not free variables"
-  (should=
-   '(x)
+  (should
+   (equal
+    '(x)
 
-   (emr-el:free-variables
-    '(list x 'y))))
+    (emr-el:free-variables
+     '(list x 'y)))))
 
 (check "elisp--finds free vars in let* form"
-  (should=
-   '(a b c d)
+  (should
+   (equal
+    '(a b c d)
 
-   (emr-el:free-variables
-    '(let* (x (y a))
-       b
-       (let* (z w)
-         c
-         (list d))))))
+    (emr-el:free-variables
+     '(let* (x (y a))
+        b
+        (let* (z w)
+          c
+          (list d)))))))
 
 (check "elisp--finds free vars in lambda form"
-  (should=
-   '(a b c)
+  (should
+   (equal
+    '(a b c)
 
-   (emr-el:free-variables
-    '(lambda (x &rest y)
-       a
-       (list b)
-       (lambda (z w)
-         c)))))
+    (emr-el:free-variables
+     '(lambda (x &rest y)
+        a
+        (list b)
+        (lambda (z w)
+          c))))))
 
 (check "elisp--finds free vars in progn form"
-  (should=
-   '(a b c)
+  (should
+   (equal
+    '(a b c)
 
-   (emr-el:free-variables
-    '(progn
-       a
-       (lambda (x &rest y) b)
-       (let (z w) c)))))
+    (emr-el:free-variables
+     '(progn
+        a
+        (lambda (x &rest y) b)
+        (let (z w) c))))))
 
 (check "elisp--finds free vars in cl-destructuring-bind"
-  (should=
-   '(a b c d)
+  (should
+   (equal
+    '(a b c d)
 
-   (emr-el:free-variables
-    '(cl-destructuring-bind (x y) (list 1 2)
-       a
-       (list b)
-       (cl-destructuring-bind (z . w) (list 3 4 5)
-         (list c d))))))
+    (emr-el:free-variables
+     '(cl-destructuring-bind (x y) (list 1 2)
+        a
+        (list b)
+        (cl-destructuring-bind (z . w) (list 3 4 5)
+          (list c d)))))))
 
 (check "elisp--finds free vars in defun form"
-  (should=
-   '(a b)
+  (should
+   (equal
+    '(a b)
 
-   (emr-el:free-variables
-    '(defun hello (x y)
-       (list a x)
-       (progn
-         (list b y))))))
+    (emr-el:free-variables
+     '(defun hello (x y)
+        (list a x)
+        (progn
+          (list b y)))))))
 
 (check "elisp--survives function symbol followed by non-lambda term"
   (let ((fname (cl-gensym)))
-    (should=
-     `(,fname)
+    (should
+     (equal
+      `(,fname)
 
-     (emr-el:free-variables
-      `(function ,fname)))))
+      (emr-el:free-variables
+       `(function ,fname))))))
 
 (check "elisp--checks outer scope for bindings that share names with functions"
-  (should=
-   '(message y)
+  (should
+   (equal
+    '(message y)
 
-   (emr-el:free-variables '(funcall message y)
-                        '(let (message)
-                           (funcall message y)))))
+    (emr-el:free-variables '(funcall message y)
+                           '(let (message)
+                              (funcall message y))))))
 
 ;;;; Inspecting forms at point
 

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -34,13 +34,4 @@
 ;; suddenly our examples don't contain valid elisp.
 (setq text-quoting-style 'straight)
 
-(defmacro check (desc &rest body)
-  "Wrap `ert-deftest' with a simpler interface.
-DESC is a string describing the test.
-BODY lists the forms to be executed."
-  (declare (indent 1))
-  `(ert-deftest
-       ,(intern (replace-regexp-in-string "[ .]" "_" desc)) ()
-     ,@body))
-
 ;;; test-helper.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,6 +1,7 @@
 ;;; test-utils.el --- Common utilities for emr tests  -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2013 Chris Barrett
+;; Copyright (C) 2018 Wilfred Hughes
 
 ;; Author: Chris Barrett <chris.d.barrett@me.com>
 
@@ -25,9 +26,16 @@
 
 ;;; Code:
 
+(require 'ert)
+(require 'f)
+
+(let ((helpful-dir (f-parent (f-dirname (f-this-file)))))
+  (add-to-list 'load-path helpful-dir))
+
 (require 'undercover)
-(undercover "*.el")
-(require 'emr-elisp)
+(undercover "emr*.el"
+	    (:exclude "*-test.el")
+	    (:report-file "/tmp/undercover-report.json"))
 
 ;; FIXME: this is an ugly hack. Tests fail in 25.1 without this.  When
 ;; we read the docstring, Emacs converts ' to ` by default and

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -43,8 +43,4 @@ BODY lists the forms to be executed."
        ,(intern (replace-regexp-in-string "[ .]" "_" desc)) ()
      ,@body))
 
-(defun should= (x y)
-  "Assert that objects X and Y are equal."
-  (should (equal x y)))
-
 ;;; test-helper.el ends here


### PR DESCRIPTION
The advantages of ert-deftest are:

- It's namespaced (unlike check), and tests are now clearly
  namespaced, so you can cleanly run these tests in your current Emacs
  instance.
- It's obvious what name the test functions have, making it easier to
  run them from M-x ert.
- It's familiar to more Emacsers.