### PR TITLE
A top-level let is not a defun

### DIFF
--- a/emr-elisp.el
+++ b/emr-elisp.el
@@ -239,11 +239,7 @@ CONTEXT is the top level form that encloses FORM."
 
 (defun emr-el:looking-at-definition? ()
   "Non-nil if point is at a definition form."
-  (or (ignore-errors (emr-el:definition? (list-at-point)))
-      (-when-let (def (thing-at-point 'defun))
-        (->> (emr-el:safe-read def)
-          (cl-third)
-          (emr-el:find-in-tree (list-at-point))))))
+  (ignore-errors (emr-el:definition? (list-at-point))))
 
 ;;;; Refactoring commands
 

--- a/test/emr-elisp-test.el
+++ b/test/emr-elisp-test.el
@@ -127,6 +127,15 @@
                         '(let (message)
                            (funcall message y)))))
 
+;;;; Inspecting forms at point
+
+(check "elisp--a top level let is not a definition"
+  (with-temp-buffer
+    (insert "(let ((x 1))\n  (message \"foo: %s %s\" x 'bar))")
+    (goto-char (point-min))
+    (search-forward "message")
+    (should (not (emr-el:looking-at-definition?)))))
+
 ;;;; Commands
 
 (defstruct emr-el-test-spec form before after)


### PR DESCRIPTION
This thing-at-point call was introduced in
3cd52f4993f73b53de8a4f380e2f5a7b75e40437, but I'm unable to find a
scenario where the third element in a sexp is indicative of a
definition.

I've added a test so if this has broken a feature, we can ensure that
the use case here stays fixed.

Fixes #31