### PR TITLE
only newline-and-indent if the let form has existing bindings

### DIFF
--- a/emr-elisp.el
+++ b/emr-elisp.el
@@ -905,7 +905,8 @@ VAL should be a string of elisp source code."
             (progn
               (goto-char vars-end)
               (backward-char)
-              (newline-and-indent))
+	      (when (> (length let-vars) 0)
+		(newline-and-indent)))
           ;; Move up s-expressions until we're at the beginning of the
           ;; variable declaration.
           ;; (let (|(x foo)) ...)


### PR DESCRIPTION
Not sure if this is correct but it makes https://github.com/Wilfred/emacs-refactor/issues/52 go away.