### PR TITLE
fix: obsolete call to `emr-c-mode' in `emr-c-initialize'

### DIFF
--- a/emr-c.el
+++ b/emr-c.el
@@ -297,8 +297,7 @@ Uses either clang-format, if available, or `emr-c-format-fallback-func.'"
   (--each (buffer-list)
     (with-current-buffer it
       (when (derived-mode-p 'c-mode)
-        (emr-c:show-menu)
-        (emr-c-mode +1)))))
+        (emr-c:show-menu)))))
 
 (provide 'emr-c)
 


### PR DESCRIPTION
It looks like this was missed when `emr-c-mode' was removed.