### PR TITLE
fix package-lint warnings

### DIFF
--- a/emr-elisp.el
+++ b/emr-elisp.el
@@ -43,10 +43,10 @@ Used when searching for usages across the whole buffer."
   :group 'emr)
 
 (defun emr-el:safe-read (sexp)
-  "A wrapper around `read' that returns nil immediately if SEXP is null.
+  "A wrapper around `read' that return nil immediately if SEXP is null.
 
-If sexp is nil, `read' would prompt the user for input from
-stdin. Bad."
+If sexp is nil, `read' would prompt the user for input from stdin.
+Bad."
   (and sexp (read sexp)))
 
 (defun emr-el:print (form)
@@ -274,8 +274,7 @@ BEFORE:
 
 AFTER:
 
-  (usage value)
- "
+  (usage value)"
   (interactive "*")
   (save-excursion
     (emr-lisp-back-to-open-round)
@@ -322,8 +321,7 @@ BEFORE:
 
 AFTER:
 
-  (+ 3 3)
-"
+  (+ 3 3)"
   (interactive "*")
   (emr-lisp-extraction-refactor (sexp) "Replacement at"
 
@@ -411,8 +409,7 @@ AFTER:
     (application x))
 
   (defun orig (x)
-    (extracted x))
-"
+    (extracted x))"
   (interactive
    (list
     ;; Function name.
@@ -465,8 +462,7 @@ AFTER:
   (defun hello (x y)
     )
 
-  (hello x y)
-"
+  (hello x y)"
   (interactive (list
                 (emr-el:safe-read
                  (emr-el:read-with-default "Name" (symbol-at-point)))
@@ -528,8 +524,7 @@ AFTER:
 
   (defvar x (+ 1 2))
 
-  (usage x)
-"
+  (usage x)"
   (interactive "*sName: ")
   (when (s-blank? name)
     (user-error "Name must not be blank"))
@@ -556,9 +551,7 @@ AFTER:
 
   (defconst x (+ 1 2))
 
-  (usage x)
-
-"
+  (usage x)"
   (interactive "*sName: ")
   (when (s-blank? name)
     (user-error "Name must not be blank"))
@@ -571,11 +564,11 @@ AFTER:
 ; ------------------
 
 (defun emr-el:autoload-exists? (function str)
-  "Returns true if an autoload for FUNCTION exists in string STR."
+  "Return non-nil if an autoload for FUNCTION exists in string STR."
   (s-contains? (format "(autoload '%s " function) str))
 
 (defun emr-el:beginning-of-defun ()
-  "A safe version of beginning-of-defun.
+  "A safe version of `beginning-of-defun'.
 Attempts to find an enclosing defun form first, rather than
 relying on indentation."
   (or
@@ -611,8 +604,7 @@ BEFORE:
 AFTER:
 
   ;;;###autoload
-  (defun hello ())
-"
+  (defun hello ())"
   (interactive "*")
   (unless (emr-el:autoload-directive-exsts-above-defun?)
     (emr-reporting-buffer-changes "Inserted autoload"
@@ -819,8 +811,7 @@ Move to that body form that encloses point."
          (throw 'found nil))))))
 
 (defun emr-el:let-start-pos ()
-  "Search upward form point to find the start position of
-the innermost let."
+  "Search upward form point to find the start position of the innermost let."
   (let ((positions
          (list
           (emr-lisp-find-upwards 'let)
@@ -847,8 +838,7 @@ BEFORE:
 AFTER:
 
   (let ((x 1))
-    (+ x 1))
-"
+    (+ x 1))"
   (interactive)
   (save-excursion
     (goto-char (emr-el:let-start-pos))
@@ -871,8 +861,7 @@ AFTER:
 
 ;; https://github.com/Wilfred/emacs-refactor/issues/35
 (defun emr-el:add-let-binding (var val)
-  "Add a binding for symbol VAR assigned to VAL to the
-innermost let form at point.
+  "Add a binding for symbol VAR assigned to VAL to the innermost let form.
 
 Ensures that VAR is inserted before point.
 
@@ -973,7 +962,7 @@ VAL should be a string of elisp source code."
 
 (defun emr-el:goto-start-of-let-binding ()
   "Move to the opening paren of the let-expression at point.
-  Otherwise move to the previous one in the current top level form."
+Otherwise move to the previous one in the current top level form."
   (-when-let (pos (emr-el:let-start-pos))
     (when (< 0 pos)
       (goto-char pos)
@@ -1050,7 +1039,7 @@ For example:
                  (zerop (emr-el:point-sexp-index))))))))
 
 (defun emr-el:let-bindings-recursively-depend? (elt bindings)
-  "Non-nil if the given let bindings list has recursive dependency on ELT."
+  "Non-nil if the given let BINDINGS list has recursive dependency on ELT."
   (-when-let* ((b   (--first (equal elt (emr-el:first-atom it)) bindings))
                (pos (cl-position b bindings :test 'equal)))
     (-> (-split-at (1+ pos) bindings)
@@ -1101,8 +1090,7 @@ BEFORE:
 AFTER:
 
   (let ((x 1))
-    (+ x 2))
-"
+    (+ x 2))"
   (interactive "*")
   (cl-assert (emr-el:looking-at-let-binding-symbol?))
   (save-excursion
@@ -1141,7 +1129,7 @@ AFTER:
 ; ------------------
 
 (defun emr-el:extract-arguments-in-usage-form (usage)
-  "Given a function usage form, extract the arguments applied to the function."
+  "Given a function USAGE form, extract the arguments applied to the function."
   (with-temp-buffer
     (save-excursion (insert usage))
     ;; Move to funcall parameters.
@@ -1192,7 +1180,7 @@ AFTER:
     (buffer-string)))
 
 (defun emr-el:transform-function-usage (def usage)
-  "Replace the usage of a function with the body from its definition.
+  "Replace the USAGE of a function with the body from its DEF.
 Its variables will be let-bound."
   (let* ((params (->> (emr-el:safe-read def)
                    (emr-el:defun-arglist-symbols)
@@ -1279,13 +1267,13 @@ Replaces all usages in the current buffer."
 ; ------------------
 
 (defun emr-el:def-name (definition-form)
-  "Given a defvar/defun/... form, return its name."
+  "Given a DEFINITION-FORM such as defvar/defun/..., return its name."
   (let* ((form-name (nth 1 definition-form)))
     (when (symbolp form-name)
       form-name)))
 
 (defun emr-el:def-find-usages (definition-form)
-  "Find the usages for a given symbol.
+  "Find the usages for a given DEFINITION-FORM symbol.
 
 Returns a list of conses, where the car is the line number and
 the cdr is the usage form."

--- a/emr-js.el
+++ b/emr-js.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 
-;; Refactoring commands for JavaScript. Requires `js2-refactor`.
+;; Refactoring commands for JavaScript.  Requires `js2-refactor`.
 ;;
 ;;    https://github.com/magnars/js2-refactor.el
 ;;

--- a/emr-prog.el
+++ b/emr-prog.el
@@ -3,7 +3,6 @@
 ;; Copyright (C) 2013 Chris Barrett
 
 ;; Author: Chris Barrett <chris.d.barrett@me.com>
-;; Version: 20130604.0804
 
 ;; This file is not part of GNU Emacs.
 

--- a/emr-ruby.el
+++ b/emr-ruby.el
@@ -21,7 +21,7 @@
 
 ;;; Commentary:
 
-;; Refactoring support for Ruby. Requires `Ruby Refactor`.
+;; Refactoring support for Ruby.  Requires `Ruby Refactor`.
 ;;
 ;;    https://github.com/ajvargo/ruby-refactor
 ;;

--- a/emr.el
+++ b/emr.el
@@ -4,9 +4,11 @@
 ;; Copyright (C) 2016-2018 Wilfred Hughes
 
 ;; Author: Chris Barrett <chris.d.barrett@me.com>
-;; Version: 0.4.1
 ;; Keywords: tools convenience refactoring
-;; Package-Requires: ((s "1.3.1") (dash "1.2.0") (cl-lib "0.2") (popup "0.5.0") (emacs "24.1") (list-utils "0.3.0") (paredit "24.0.0") (projectile "0.9.1") (clang-format "0") (iedit "0.97"))
+;; Version: 0.4.1
+;; URL: https://github.com/Wilfred/emacs-refactor
+;; Package-Requires: ((s "1.3.1") (dash "1.2.0") (cl-lib "0.2") (popup "0.5.0") (emacs "24.1") (list-utils "0.3.0") (paredit "24.0.0") (projectile "0.9.1") (clang-format "0.0.1") (iedit "0.97"))
+
 ;; This file is not part of GNU Emacs.
 
 ;; This program is free software: you can redistribute it and/or modify
@@ -93,7 +95,7 @@ If the defun is preceded by comments, move above them."
   (save-excursion (nth 3 (syntax-ppss))))
 
 (defun emr-looking-at-comment? (&optional pos)
-  "Non-nil if point is on a comment."
+  "Non-nil if POS is on a comment."
   (save-excursion
     (nth 4 (syntax-ppss pos))))
 
@@ -180,7 +182,7 @@ buffer."
       (message))))
 
 (defun emr:line-visible? (line)
-  "Return true if LINE is within the visible bounds of the current window."
+  "Return non-nil if LINE is within the visible bounds of the current window."
   (let* ((min (line-number-at-pos (window-start)))
          (max (line-number-at-pos (window-end))))
     (and (>= line min) (<= line max))))
@@ -217,7 +219,7 @@ buffer."
 
 (defun emr:documentation (sym)
   "Get the docstring for SYM.
-Removes the function arglist and lisp usage example."
+Removes the function arglist and Lisp usage example."
   (cl-destructuring-bind (before-example &optional after-example)
       (->> (documentation sym)
         (s-lines)
@@ -271,8 +273,7 @@ Removes the function arglist and lisp usage example."
             :title title
             :modes (if (symbolp modes) (list modes) modes)
             :predicate predicate
-            :description description
-            )
+            :description description)
            emr:refactor-commands))
 
 (defun emr:hash-values (ht)


### PR DESCRIPTION
Hi! I found this package and fix compiler/linter warnings for my contribution first step.

I resolve many issues but some warnings still remained.

## before
### emr.el

``` emacs-lisp
Package should have a Homepage or URL header. (emacs-lisp-package)
Use a properly versioned dependency on "clang-format" if possible. (emacs-lisp-package)
Argument ‘pos’ should appear (as POS) in the doc string (emacs-lisp-checkdoc)
`emr:indexed-lines' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:diff-lines' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:report-action' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:line-visible?' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
"true" should usually be "non-nil" (emacs-lisp-checkdoc)
`emr:refactor-commands' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:documentation' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
Name lisp should appear capitalized as Lisp (emacs-lisp-checkdoc)
Closing parens should not be wrapped onto new lines. (emacs-lisp-package)
`emr:hash-values' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:make-popup' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
```

### emr-elisp.el
``` emacs-lisp
Probably "returns" should be imperative "return" (emacs-lisp-checkdoc)
There should be two spaces after a period (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
Probably "Returns" should be imperative "Return" (emacs-lisp-checkdoc)
Lisp symbol ‘beginning-of-defun’ should appear in quotes (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
First line is not a complete sentence (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
First line is not a complete sentence (emacs-lisp-checkdoc)
Second line should not have indentation (emacs-lisp-checkdoc)
Argument ‘bindings’ should appear (as BINDINGS) in the doc string (emacs-lisp-checkdoc)
First line is not a complete sentence (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
Documentation strings should not start or end with whitespace (emacs-lisp-checkdoc)
Argument ‘usage’ should appear (as USAGE) in the doc string (emacs-lisp-checkdoc)
Argument ‘def’ should appear (as DEF) in the doc string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
Argument ‘definition-form’ should appear (as DEFINITION-FORM) in the doc string (emacs-lisp-checkdoc)
Argument ‘definition-form’ should appear (as DEFINITION-FORM) in the doc string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
```

## after
### emr.el
``` emacs-lisp
`emr:indexed-lines' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:diff-lines' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:report-action' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:line-visible?' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:refactor-commands' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:documentation' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:hash-values' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`emr:make-popup' contains a non-standard separator `:', use hyphens instead (see Elisp Coding Conventions). (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
`eval-after-load' is for use in configurations, and should rarely be used in packages. (emacs-lisp-package)
```

### emr-elisp.el
``` emacs-lisp
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
First line is not a complete sentence (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
All variables and subroutines might as well have a documentation string (emacs-lisp-checkdoc)
```