### PR TITLE
`emr-cc-add-include-guard`: skip trailing comments

### DIFF
--- a/emr-c.el
+++ b/emr-c.el
@@ -218,7 +218,8 @@ result, if non-nil, after \"#endif \" (note the space)."
             ""))))))
 
 (defun emr-cc-delete-include-guard ()
-  "Remove the current buffer's include guard."
+  "Remove the current buffer's include guard.
+Return non-nil if an include guard was actually removed."
   (interactive)
   (save-excursion
     (emr-cc--beginning-of-header)
@@ -239,7 +240,9 @@ result, if non-nil, after \"#endif \" (note the space)."
           ;; `emr-cc-add-include-guard'). User's own whitespace management
           ;; solutions (e.g. `ws-butler') can fix this.
           (when (eq (char-before) ?\n)
-            (delete-char -1)))))))
+            (delete-char -1)))
+        ;; Success, even if there was no #endif.
+        t))))
 
 (defun emr-cc-add-pragma-once ()
   "Add #pragma once."
@@ -249,13 +252,24 @@ result, if non-nil, after \"#endif \" (note the space)."
     (insert "#pragma once\n\n")))
 
 (defun emr-cc-delete-pragma-once ()
-  "Remove #pragma once."
+  "Remove #pragma once.
+Return non-nil if a #pragma once was removed."
   (interactive)
   (save-excursion
     (emr-cc--beginning-of-header)
     (save-match-data
       (when (looking-at (rx "#" (* space) "pragma" (* space) "once" (* any) (** 0 2 ?\n)))
-        (replace-match "")))))
+        (replace-match "")
+        t))))
+
+(defun emr-cc-toggle-include-guard ()
+  "Toggle between #pragma once and include guards."
+  (interactive)
+  (if (emr-cc-delete-pragma-once)
+      (emr-cc-add-include-guard)
+    (unless (emr-cc-delete-include-guard)
+      (user-error "Current buffer contains neither an include guard nor #pragma once"))
+    (emr-cc-add-pragma-once)))
 
 
 (defun emr-c:headers-in-project ()

--- a/emr-c.el
+++ b/emr-c.el
@@ -234,8 +234,8 @@ value of `emr-cc-include-guard-space'."
   (save-excursion
     (emr-cc--beginning-of-header)
     (looking-at
-     (rx bol "#" (* space) "ifndef" (* space) (group (+ any) symbol-end) (* any) "\n"
-         bol "#" (* space) "define" (* space) (backref 1) symbol-end (* any) "\n"
+     (rx bol (* space) "#" (* space) "ifndef" (* space) (group (+ any) symbol-end) (* any) "\n"
+         bol (* space) "#" (* space) "define" (* space) (backref 1) symbol-end (* any) "\n"
          (? "\n")))))
 
 (defun emr-cc-delete-include-guard ()
@@ -281,7 +281,7 @@ Return non-nil if an include guard was actually removed."
 (defun emr-cc--looking-at-pragma-once ()
   (save-excursion
     (emr-cc--beginning-of-header)
-    (looking-at (rx "#" (* space) "pragma" (* space) "once" (* any) (** 0 2 ?\n)))))
+    (looking-at (rx bol (* space) "#" (* space) "pragma" (* space) "once" (* any) (** 0 2 ?\n)))))
 
 (defun emr-cc-delete-pragma-once ()
   "Remove #pragma once.

--- a/emr-c.el
+++ b/emr-c.el
@@ -173,11 +173,15 @@ also be a string, in which case that is inserted instead."
 If this is non-nil, `emr-cc-add-include-guard' will insert the
 result of calling this function with the include guard (see
 `emr-cc-include-guard-style') as only argument and insert its
-result, if non-nil, after \"#endif \" (note the space)."
+result, if non-nil, after \"#endif \" (note the space). If this
+variable is a string, it will be `format'ted with the include
+guard as second argument and inserted the same way as if it were
+a function."
   :type '(choice (const :tag "/* GUARD */" emr-cc-include-guard-suffix-c89)
                  (const :tag "// GUARD" emr-cc-include-guard-suffix-comment)
                  (const :tag "No #endif suffix" nil)
-                 (function :tag "custom function")))
+                 (function :tag "custom function")
+                 (string :tag "Format string (one argument)")))
 
 (defun emr-cc--include-guard-space ()
   "Return a string to insert for `emr-cc-include-guard-space'."
@@ -213,7 +217,11 @@ result, if non-nil, after \"#endif \" (note the space)."
        (format
         "\n#%sendif%s"
         (emr-cc--include-guard-space)
-        (or (-some->> (-some-> emr-cc-include-guard-suffix (funcall guard))
+        (or (-some->>
+                (-some-> emr-cc-include-guard-suffix
+                  (cl-etypecase
+                      (string (format emr-cc-include-guard-suffix guard))
+                    (function (funcall emr-cc-include-guard-suffix guard))))
               (concat " "))
             ""))))))
 

--- a/emr-c.el
+++ b/emr-c.el
@@ -198,7 +198,15 @@ value of `emr-cc-include-guard-space'."
   ;; Skip comment(s) and whitespace (e.g. license header)
   (let ((parse-sexp-ignore-comments t))
     (forward-sexp))
-  (beginning-of-defun))
+  (beginning-of-line))
+
+(defun emr-cc--end-of-header ()
+  "Go to bol at the end of the source file, skipping comments."
+  (goto-char (point-max))
+  (let ((parse-sexp-ignore-comments t))
+    (backward-sexp)
+    (forward-sexp))
+  (beginning-of-line))
 
 (defun emr-cc-add-include-guard ()
   "Add an include guard to the current buffer."
@@ -247,10 +255,7 @@ Return non-nil if an include guard was actually removed."
       (replace-match "")
 
       (save-excursion
-        (goto-char (point-max))
-        (let ((parse-sexp-ignore-comments t))
-          (backward-sexp))
-        (end-of-defun)
+        (emr-cc--end-of-header)
         (when (looking-at (rx bol "#" (* space) "endif" symbol-end (* any) eol))
           (replace-match "")
           ;; We can't know if the file should end in a newline, so don't delete

--- a/emr-c.el
+++ b/emr-c.el
@@ -193,10 +193,12 @@ value of `emr-cc-include-guard-space'."
     (_ " ")))
 
 (defun emr-cc--beginning-of-header ()
+  "Go to the start of the source file, skipping comments."
   (goto-char (point-min))
   ;; Skip comment(s) and whitespace (e.g. license header)
-  (forward-sexp)
-  (beginning-of-line))
+  (let ((parse-sexp-ignore-comments t))
+    (forward-sexp))
+  (beginning-of-defun))
 
 (defun emr-cc-add-include-guard ()
   "Add an include guard to the current buffer."
@@ -241,8 +243,9 @@ Return non-nil if an include guard was actually removed."
         (replace-match "")
 
         (goto-char (point-max))
-        (backward-sexp)
-        (beginning-of-line)
+        (let ((parse-sexp-ignore-comments t))
+          (backward-sexp))
+        (end-of-defun)
         (when (looking-at (rx bol "#" (* space) "endif" symbol-end (* any) eol))
           (replace-match "")
           ;; We can't know if the file should end in a newline, so don't delete

--- a/emr-c.el
+++ b/emr-c.el
@@ -224,7 +224,8 @@ value of `emr-cc-include-guard-space'."
 "
         guard (or emr-cc-include-guard-value "")
         (emr-cc--include-guard-space emr-cc-include-guard-space)))
-      (goto-char (point-max))
+      (emr-cc--end-of-header)
+      (forward-line)
       (unless (= (char-before) ?\n)
         (insert ?\n))
       (insert

--- a/emr-c.el
+++ b/emr-c.el
@@ -197,7 +197,9 @@ value of `emr-cc-include-guard-space'."
   (goto-char (point-min))
   ;; Skip comment(s) and whitespace (e.g. license header)
   (let ((parse-sexp-ignore-comments t))
-    (forward-sexp))
+    (with-syntax-table (copy-syntax-table (syntax-table))
+      (modify-syntax-entry ?\\ " ")
+      (forward-sexp)))
   (beginning-of-line))
 
 (defun emr-cc--end-of-header ()


### PR DESCRIPTION
- Add an include guard
- Remove an include guard
- Add #pragma once
- Remove #pragma once
- Toggle between include guards/#pragma once
- All of the above exposed in the menu, context sensitive (i.e. no "remove
  include guards" if there are none)
- Skips comments at the start and end of the buffer (i.e. copyright
  boilerplates, "LocalWords: ")
- A lot of customization options (custom include guard symbol generators, text
  after `#endif`, spaces after `#`, ...)
- Handles lots of tricky edge cases:

```c++
#ifndef Q
#define Q

in\
t main() {}

#endif /* Q */```

->

```c++
#ifndef Q
#define Q

in\
t main() {}

#endif /* Q */
```

Fixes #62.
  
----

#