### PR TITLE
Replace `return` calls with `cl-return` calls

### DIFF
--- a/emr-elisp.el
+++ b/emr-elisp.el
@@ -577,7 +577,7 @@ relying on indentation."
     while (ignore-errors (backward-up-list) t)
     do (when (thing-at-point-looking-at
               (rx-to-string `(seq "(" (or ,@(-map 'symbol-name emr-el-definition-macro-names)))))
-         (return (point))))
+         (cl-return (point))))
    ;; Fall back to using indentation.
    (ignore-errors
      (beginning-of-thing 'defun))))

--- a/emr-lisp.el
+++ b/emr-lisp.el
@@ -54,7 +54,7 @@
      while (ignore-errors (backward-up-list) t)
      when (thing-at-point-looking-at
            (rx-to-string `(seq "(" ,(symbol-name sym) symbol-end)))
-     do (return (point)))))
+     do (cl-return (point)))))
 
 ; ------------------
 


### PR DESCRIPTION
`return` is an obsolete command and it was causing issues on emacs 28,
so I simply replaced it with `cl-return`. I'm not sure if this breaks
some compatibility though.