### PR TITLE
fix: require compile

### DIFF
--- a/emr-elisp.el
+++ b/emr-elisp.el
@@ -30,9 +30,9 @@
 (require 'list-utils)
 (require 'dash)
 (require 'thingatpt)
+(require 'compile)
 (require 'emr)
 (require 'emr-lisp)
-(autoload 'define-compilation-mode "compile")
 (autoload 'paredit-splice-sexp-killing-backward "paredit")
 
 (defcustom emr-el-definition-macro-names


### PR DESCRIPTION
`define-compilation-mode` is evaluated at the top level, so it should be `(require 'compile)`. Without `require`, it fails to byte-compile.